### PR TITLE
PSR2/UseDeclaration: simplify the fix

### DIFF
--- a/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
@@ -157,6 +157,15 @@ class UseDeclarationSniff implements Sniff
 
         --$end;
 
+        if (($tokens[$end]['code'] === T_COMMENT
+            || isset(Tokens::$phpcsCommentTokens[$tokens[$end]['code']]) === true)
+            && substr($tokens[$end]['content'], 0, 2) === '/*'
+            && substr($tokens[$end]['content'], -2) !== '*/'
+        ) {
+            // Multi-line block comments are not allowed as trailing comment after a use statement.
+            --$end;
+        }
+
         $next = $phpcsFile->findNext(T_WHITESPACE, ($end + 1), null, true);
 
         if ($next === false || $tokens[$next]['code'] === T_CLOSE_TAG) {

--- a/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
@@ -138,18 +138,24 @@ class UseDeclarationSniff implements Sniff
         }
 
         $end = $phpcsFile->findNext(T_SEMICOLON, ($stackPtr + 1));
-        $candidateComment = $end;
-
-        do {
-            $nextComment      = $candidateComment;
-            $candidateComment = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextComment + 1));
-        } while ($candidateComment !== false && $tokens[$candidateComment]['line'] === $tokens[$end]['line']);
-
-        $end = $nextComment;
-
         if ($end === false) {
             return;
         }
+
+        // Find either the start of the next line or the beginning of the next statement,
+        // whichever comes first.
+        for ($end = ++$end; $end < $phpcsFile->numTokens; $end++) {
+            if (isset(Tokens::$emptyTokens[$tokens[$end]['code']]) === false) {
+                break;
+            }
+
+            if ($tokens[$end]['column'] === 1) {
+                // Reached the next line.
+                break;
+            }
+        }
+
+        --$end;
 
         $next = $phpcsFile->findNext(T_WHITESPACE, ($end + 1), null, true);
 

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.11.inc
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.11.inc
@@ -1,0 +1,2 @@
+<?php
+use Foo\Bar; class Baz {}

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.11.inc.fixed
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.11.inc.fixed
@@ -1,0 +1,4 @@
+<?php
+use Foo\Bar; 
+
+class Baz {}

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.12.inc
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.12.inc
@@ -1,0 +1,9 @@
+<?php
+use Foo\Bar; /*
+ * This multi-line comment shouldn't be allowed here.
+ */
+
+class Baz
+{
+
+}

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.12.inc.fixed
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.12.inc.fixed
@@ -1,0 +1,11 @@
+<?php
+use Foo\Bar; 
+
+/*
+ * This multi-line comment shouldn't be allowed here.
+ */
+
+class Baz
+{
+
+}

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.13.inc
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.13.inc
@@ -1,0 +1,10 @@
+<?php
+use Foo\Bar; // trailing comment
+/*
+ * This multi-line comment shouldn't be allowed here.
+ */
+
+class Baz
+{
+
+}

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.13.inc.fixed
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.13.inc.fixed
@@ -1,0 +1,11 @@
+<?php
+use Foo\Bar; // trailing comment
+
+/*
+ * This multi-line comment shouldn't be allowed here.
+ */
+
+class Baz
+{
+
+}

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.14.inc
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.14.inc
@@ -1,0 +1,8 @@
+<?php
+use Foo\Bar; // trailing comment
+/* phpcs:ignore Standard.Category.Sniff -- for reasons */
+
+class Baz
+{
+
+}

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.14.inc.fixed
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.14.inc.fixed
@@ -1,0 +1,9 @@
+<?php
+use Foo\Bar; // trailing comment
+
+/* phpcs:ignore Standard.Category.Sniff -- for reasons */
+
+class Baz
+{
+
+}

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.php
@@ -50,6 +50,7 @@ class UseDeclarationUnitTest extends AbstractSniffUnitTest
                 19 => 1,
             ];
         case 'UseDeclarationUnitTest.10.inc':
+        case 'UseDeclarationUnitTest.11.inc':
             return [2 => 1];
         default:
             return [];

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.php
@@ -51,6 +51,9 @@ class UseDeclarationUnitTest extends AbstractSniffUnitTest
             ];
         case 'UseDeclarationUnitTest.10.inc':
         case 'UseDeclarationUnitTest.11.inc':
+        case 'UseDeclarationUnitTest.12.inc':
+        case 'UseDeclarationUnitTest.13.inc':
+        case 'UseDeclarationUnitTest.14.inc':
             return [2 => 1];
         default:
             return [];


### PR DESCRIPTION
Based on a review of upstream PR squizlabs/PHP_CodeSniffer#1893, please find this as an optional suggestion for simplifying the logic a little.

All unit tests - including the new ones - still pass with this change included.
Added one more unit test case which looked like it wasn't covered yet.